### PR TITLE
fix bug of behind where has space and no params,has not ignore where

### DIFF
--- a/src/lib/sqlContainer.js
+++ b/src/lib/sqlContainer.js
@@ -92,7 +92,7 @@ class SqlContainer {
             }
         }
         result = rawSql.join(' ')
-        let lastWhereReg = /\s+where$/i
+        let lastWhereReg = /\s+where\s*$/i
         let whereAndReg = /\s+where\s+and\s+/ig
         let whereOtherReg = /\s+where\s+(union\s+|order\s+|group\s+|limit\s+)/gi
         result = result.replace(lastWhereReg, '')


### PR DESCRIPTION
在条件查询时，格式为where {{namespace.key}}的时候，因为查询条件都为空的情况下，sql组装后会有where  的情况而导致无法忽略where  ,源代码中的匹配是/\s+where$/i,个人认为应该匹配：/\s+where\s*$/i的形式。
若提交不符合源代码规范或与其他内容冲突，请忽略。